### PR TITLE
fix(cms): remove duplicate field tags

### DIFF
--- a/public/config.yml
+++ b/public/config.yml
@@ -108,13 +108,6 @@ collections:
         label: Classification
         widget: select
         options: [ 'Book', 'Chapter', 'Article', 'Dissertation' ]
-      - name: tags
-        label: Project Tags
-        widget: list
-        min: 1
-        max: 2
-        collapsed: false
-        field: { label: Project, name: project, widget: select, options: ["MMP", "LAMP"] }
       - name: author
         label: Author(s)
         widget: text


### PR DESCRIPTION
CMS broke due to publications having two "tag" fields in the config.